### PR TITLE
Add validation error display to login form

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -37,6 +37,7 @@
             focus:border-green-50 border-green-50 focus:ring-0 rounded-none focus:outline-none">
                 </div>
             </div>
+                <x-input-error :messages="$errors->get('email')" class="mt-2" />
 
 
 
@@ -55,6 +56,7 @@
                     </button>
                 </div>
             </div>
+                <x-input-error :messages="$errors->get('password')" class="mt-2" />
 
             <!-- Remember Me Checkbox (di sebelah kiri) -->
            


### PR DESCRIPTION
## Summary
- show validation errors under email and password inputs in login page

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ea98c5b588323837e82968a205a33