### PR TITLE
Add Firestore accessor methods

### DIFF
--- a/app/Http/Controllers/FirestoreController.php
+++ b/app/Http/Controllers/FirestoreController.php
@@ -18,7 +18,7 @@ class FirestoreController extends Controller
 
     public function index()
     {
-        $firestore = $this->firebase->getFireStore();
+        $firestore = $this->firebase->getFirestore();
         $collection = $firestore->collection('users');
         $documents = $collection->documents();
 

--- a/app/Http/Controllers/datakendaraan.php
+++ b/app/Http/Controllers/datakendaraan.php
@@ -3,31 +3,29 @@
 namespace App\Http\Controllers;
 
 
-use App\Http\Controllers\Controller;
 use App\Services\FirebaseService;
-use Illuminate\Http\Request;
 
 class datakendaraan extends Controller
 {
-    public function index ()
-    {
-        return view('datakendaraan.index');
+    protected FirebaseService $firebase;
 
-    $documents = $firebase->getCollection('vehicles'); 
+    public function __construct(FirebaseService $firebase)
+    {
+        $this->firebase = $firebase;
+    }
+
+    public function index()
+    {
+        // Fetching documents just to ensure Firestore connection is used.
+        $documents = $this->firebase->getCollection('vehicles');
 
         $data = [];
-
         foreach ($documents as $doc) {
-            $data[] = [
-                'userId' => $doc['userId'],
-                'model' => $doc['model'],
-                'nomor_polisi' => $doc['nomor_polisi'],
-                'tipe_bensin' => $doc['tipe_bensin'],
-                'transmisi' => $doc['transmisi'],
-                'kilometer' => $doc['kilometer'],
-            ];
+            if ($doc->exists()) {
+                $data[] = $doc->data();
+            }
         }
 
-        return view('firebase.index', compact('data'));
+        return view('datakendaraan.index', compact('data'));
     }
 }

--- a/app/Services/FirebaseService.php
+++ b/app/Services/FirebaseService.php
@@ -15,6 +15,22 @@ class FirebaseService
         ]);
     }
 
+    /**
+     * Get the underlying Firestore client instance.
+     */
+    public function getFirestore()
+    {
+        return $this->firestore;
+    }
+
+    /**
+     * Convenience helper to return all documents from a collection.
+     */
+    public function getCollection(string $name)
+    {
+        return $this->firestore->collection($name)->documents();
+    }
+
     public function testConnection()
     {
         try {


### PR DESCRIPTION
## Summary
- expose Firestore client via `getFirestore()` and add `getCollection()` helper
- update controllers to use the new Firebase service methods

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ea986b2908323b2422765bc7724f6