### PR TITLE
Fix dashboard route

### DIFF
--- a/resources/views/datakendaraan/index.blade.php
+++ b/resources/views/datakendaraan/index.blade.php
@@ -102,7 +102,7 @@
         </div>
         <ul class="space-y-1 px-2">
           <li>
-            <a href="{{ route('dashboard.index') }}" class="group flex items-center p-3 bg-neutral-50 rounded-xl hover:bg-white transition-colors duration-300 ">
+            <a href="{{ route('dashboard') }}" class="group flex items-center p-3 bg-neutral-50 rounded-xl hover:bg-white transition-colors duration-300 ">
               <div class="flex items-center justify-center w-8 h-8 text-neutral-50 bg-red-600 rounded-lg mr-3">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5">
                   <path d="M11.47 3.84a.75.75 0 011.06 0l8.69 8.69a.75.75 0 101.06-1.06l-8.689-8.69a2.25 2.25 0 00-3.182 0l-8.69 8.69a.75.75 0 001.061 1.06l8.69-8.69z" />

--- a/resources/views/jadwalservis/index.blade.php
+++ b/resources/views/jadwalservis/index.blade.php
@@ -73,7 +73,7 @@
         </div>
         <ul class="space-y-1 px-2">
           <li>
-            <a href="{{ route('dashboard.index') }}" class="group flex items-center p-3 bg-red-600 rounded-xl hover:bg-white transition-colors duration-300 ">
+            <a href="{{ route('dashboard') }}" class="group flex items-center p-3 bg-red-600 rounded-xl hover:bg-white transition-colors duration-300 ">
               <div class="flex items-center justify-center w-8 h-8 text-neutral-50 bg-red-600 rounded-lg mr-3 group-hover:text-red-600">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5"><path d="M11.47 3.84a.75.75 0 011.06 0l8.69 8.69a.75.75 0 101.06-1.06l-8.689-8.69a2.25 2.25 0 00-3.182 0l-8.69 8.69a.75.75 0 001.061 1.06l8.69-8.69z" /><path d="M12 5.432l8.159 8.159c.03.03.06.058.091.086v6.198c0 1.035-.84 1.875-1.875 1.875H15a.75.75 0 01-.75-.75v-4.5a.75.75 0 00-.75-.75h-3a.75.75 0 00-.75.75V21a.75.75 0 01-.75.75H5.625a1.875 1.875 0 01-1.875-1.875v-6.198a2.29 2.29 0 00.091-.086L12 5.43z" /></svg>
               </div>

--- a/resources/views/sparepart/index.blade.php
+++ b/resources/views/sparepart/index.blade.php
@@ -110,7 +110,7 @@
         </div>
         <ul class="space-y-1 px-2">
           <li>
-            <a href="{{ route('dashboard.index') }}" class="group flex items-center p-3 bg-neutral-50 rounded-xl hover:bg-white transition-colors duration-300 ">
+            <a href="{{ route('dashboard') }}" class="group flex items-center p-3 bg-neutral-50 rounded-xl hover:bg-white transition-colors duration-300 ">
               <div class="flex items-center justify-center w-8 h-8 text-neutral-50 bg-red-600 rounded-lg mr-3">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5">
                   <path d="M11.47 3.84a.75.75 0 011.06 0l8.69 8.69a.75.75 0 101.06-1.06l-8.689-8.69a2.25 2.25 0 00-3.182 0l-8.69 8.69a.75.75 0 001.061 1.06l8.69-8.69z" />

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,12 +20,12 @@ Route::get('/cek-firestore', function () {
 });
 
 Route::get('/firestore', [FirestoreController::class, 'index']);
-Route::get('/dashboard', function () {
-    return view('dashboard');
-})->middleware(['auth', 'verified'])->name('dashboard');
+// Dashboard route handled by controller with auth and verification
+Route::get('/dashboard', [dashboardcontroller::class, 'index'])
+    ->middleware(['auth', 'verified'])
+    ->name('dashboard');
 Route::get('/datakendaraan', [datakendaraan::class, 'index'])->name('datakendaraan.index');
 Route::get('/jadwalservis', [jadwalservis::class, 'index'])->name('jadwalservis.index');
-Route::get('/dashboard', [dashboardcontroller::class, 'index'])->name('dashboard.index');
 Route::get('/sparepart', [sparepart::class, 'index'])->name('sparepart.index');
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');


### PR DESCRIPTION
## Summary
- remove unused dashboard closure route
- secure dashboard controller route with auth/verified middleware
- reference the new dashboard route name in sidebar links

## Testing
- `composer install --no-interaction --ignore-platform-req=ext-grpc --ignore-platform-req=ext-dom --ignore-platform-req=ext-xml`
- `composer test` *(fails: required PHP extensions missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ea98687888323b358fb5218987b8a